### PR TITLE
[embedlite-components] Reset scroll position if viewport changes to out ...

### DIFF
--- a/jsscripts/embedhelper.js
+++ b/jsscripts/embedhelper.js
@@ -46,6 +46,7 @@ function EmbedHelper() {
   this.inputItemSize = 38;
   this.zoomMargin = 14;
   this.previousInputY = -1;
+  this.returnToBoundsRequested = false;
   this._init();
 }
 
@@ -314,6 +315,19 @@ EmbedHelper.prototype = {
         if (this._viewportLastResolution == 0 && this._viewportData != null) {
           this._viewportLastResolution = this._viewportData.resolution.width;
         }
+
+        // Floor cssCompositedRect.height and ceil cssPageRect.height that there needs to be more than 1px difference.
+        // Background reason being that TabChildHelper floors viewport x and y values.
+        if (!this.returnToBoundsRequested && this._viewportData.y + Math.floor(this._viewportData.cssCompositedRect.height) > Math.ceil(this._viewportData.cssPageRect.height)) {
+          let y = -this._viewportData.cssCompositedRect.height + this._viewportData.cssPageRect.height
+          var winid = Services.embedlite.getIDByWindow(content);
+          Services.embedlite.zoomToRect(winid, this._viewportData.x, y,
+                                        this._viewportData.cssCompositedRect.width, this._viewportData.cssCompositedRect.height);
+          this.returnToBoundsRequested = true;
+        } else {
+          this.returnToBoundsRequested = false;
+        }
+
         this.performReflow();
         break;
       }


### PR DESCRIPTION
...of bounds.

This is triggered for instance when virtual keyboard is open and content is flicked/panned
to the end and virtual keyboard is closed.
