### PR TITLE
Relay domcontentloaded once the root window receives it

### DIFF
--- a/jsscripts/embedhelper.js
+++ b/jsscripts/embedhelper.js
@@ -506,6 +506,7 @@ EmbedHelper.prototype = {
         if (LoginManagerContent.onContentLoaded) {
           LoginManagerContent.onContentLoaded(aEvent);
         }
+        this._handleDomContentLoaded(aEvent);
         break;
       }
       case "DOMFormHasPassword": {
@@ -539,6 +540,14 @@ EmbedHelper.prototype = {
       return false;
     }
     return this.contentDocumentIsDisplayed;
+  },
+
+  _handleDomContentLoaded: function(aEvent) {
+    let window = aEvent.target.defaultView;
+    if (window) {
+      let winid = Services.embedlite.getIDByWindow(window);
+      Services.embedlite.sendAsyncMessage(winid, "embed:domcontentloaded", JSON.stringify({ "rootFrame": window.parent === window }));
+    }
   },
 
   _handleFullScreenChanged: function(aEvent) {


### PR DESCRIPTION
Currently sailfish-browser observes "embedlite-before-first-paint" for taking capture of the web content for a tab thumbnail. When real tabs are used (multiple mozviews), context wide observing is not nice.

An alternative to "domcontentloaded" could be "MozAfterPaint" but as that event is triggered quite frequently; pan, flick, content animates itself (e.g. advertisement) I think that "domcontentloaded" gives good enough result for the purpose. We can revise this if needed. What do you think?
