### PR TITLE
Improve input zooming

### DIFF
--- a/jsscripts/embedhelper.js
+++ b/jsscripts/embedhelper.js
@@ -102,7 +102,7 @@ EmbedHelper.prototype = {
       focused = doc.activeElement;
     }
 
-    if (focused instanceof HTMLInputElement && focused.mozIsTextField(false))
+    if (focused instanceof HTMLInputElement && (focused.mozIsTextField && focused.mozIsTextField(false) || focused.type === "number"))
       return { inputElement: focused, isTextField: true };
 
     if (aOnlyInputElements)


### PR DESCRIPTION
Now we know composition bounds to which content will be zoomed
before virtual keyboard has been raised both for landscape and portrait.

The embedui:vkbOpenCompositionMetrics should contain following information:
- 'compositionHeight' in device pixels available height once keyboard is opened
- 'maxCssCompositionWidth' maximum composition width in css pixels
- 'maxCssCompositionHeight' maximum composition height in css pixels

All values should take into account device orientation be updated
when orientation changes.

This PR contains also a small fix / hack commit for "number" type input.
