### PR TITLE
Reset SelectionHandler state upon exception

### DIFF
--- a/jsscripts/SelectionHandler.js
+++ b/jsscripts/SelectionHandler.js
@@ -512,6 +512,7 @@ var SelectionHandler = {
       this._updateUIMarkerRects(selection);
     } catch (ex) {
       Util.dumpLn("_updateUIMarkerRects:", ex.message);
+      this._onFail("Can't update marker rects");
       return;
     }
 


### PR DESCRIPTION
Reset state upon exception. Otherwise text selection gets broken.
