### PR TITLE
Handle touch events in capture phase

### DIFF
--- a/jsscripts/embedhelper.js
+++ b/jsscripts/embedhelper.js
@@ -58,9 +58,9 @@ EmbedHelper.prototype = {
   _init: function()
   {
     dump("Init Called:" + this + "\n");
-    addEventListener("touchstart", this, false);
-    addEventListener("touchmove", this, false);
-    addEventListener("touchend", this, false);
+    addEventListener("touchstart", this, true);
+    addEventListener("touchmove", this, true);
+    addEventListener("touchend", this, true);
     addEventListener("DOMContentLoaded", this, true);
     addEventListener("DOMFormHasPassword", this, true);
     addEventListener("DOMAutoComplete", this, true);


### PR DESCRIPTION
This is needed in order to handle link clicks on sites disabling propagation of touch events with the code like this
http://pastebin.mozilla.org/4817186

Practically this is used at http://tieba.baidu.com
