### PR TITLE
Extend selection data to contain the height of lines

### DIFF
--- a/jsscripts/SelectionHandler.js
+++ b/jsscripts/SelectionHandler.js
@@ -1275,6 +1275,10 @@ var SelectionHandler = {
         }
       }
 
+      // Store end heights
+      seldata.start.height = rects[0].bottom - rects[0].top;
+      seldata.end.height = rects[rects.length-1].bottom - rects[rects.length-1].top;
+
       // Store the client rect of selection
       let r = aRange.getBoundingClientRect();
       seldata.selection.left = r.left + this._contentOffset.x;


### PR DESCRIPTION
The height of the lines at the start and end of selection is needed
to properly place selection handles. E.g. in SailfishOS design
they need to be positioned vertically centred on the lines.
