### PR TITLE
Scroll to input only if VKB is fully open

### DIFF
--- a/jsscripts/embedhelper.js
+++ b/jsscripts/embedhelper.js
@@ -418,7 +418,7 @@ EmbedHelper.prototype = {
       rect.x = cssCompositedRect.x;
     }
 
-    if (needYAxisMoving && aIsTextField) {
+    if (needYAxisMoving) {
       if (scrollToBottom) {
         rect.y = inputRect.y + inputRect.height - fixedCurrentViewport.height + margin;
       }

--- a/jsscripts/embedhelper.js
+++ b/jsscripts/embedhelper.js
@@ -340,7 +340,7 @@ EmbedHelper.prototype = {
     let scaleFactor = aIsTextField ? (this.inputItemSize / this.vkbOpenCompositionMetrics.compositionHeight) / (rect.h / cssCompositionHeight) : 1.0;
 
     let margin = this.zoomMargin / scaleFactor;
-    let allowZoom = aAllowZoom && rect.height != this.inputItemSize;
+    let allowZoom = aAllowZoom && rect.h != this.inputItemSize;
 
     // Calculate new css composition bounds that will be the bounds after zooming. Top-left corner is not yet moved.
     let cssCompositedRect = new Rect(this._viewportData.x,


### PR DESCRIPTION
The problem
    
    1. Without this commit we instruct APZC to scroll to a focused input field right
       after we get Gesture:SingleTap message originated from APZC.
    
    2. By the time APZC is instructed to scroll VKB is not opened yet. It only
       starts to open slowly.
    
    3. This means that APZC::ZoomToRect() calculates the scroll animation basing on
       FrameMetrics received from the compositor when VKB was down. According to these
       metrics the required scroll animation is going to result in a overscroll
       situation which is forbidden, and thus nothing happens.
    
    4. We could instruct APZC to scroll when VKB is fully open, but
      4.1 it seems that the signal QInputMethod.animatingChanging() is not emitted
          in SailfishOS,
      4.2 even if the signal is emitted we cannot guaranty that by the time the
          signal is emitted APZC has received fresh and correct FrameMetrics from
          Compositor corresponding to fully open VKB.
    
    So we must initiate a scroll to a focused input field only when APZC has got
    actual FrameMetrics after VKB is fully opened. However APZC knows nothing
    about VKB's actual state. Only the UI code knows that. Theoretically the UI
    code knows also the actual size and scroll position of a given WebView (both
    in CSS and device pixels) which are derived from APZC's actual FrameMetrics
    (they are communicated through APZC::SendAsyncScrollEvent() upon arrival
    of fresh FrameMetrics from Compositor). In practice though APZC doesn't send
    scroll events to subscribed listeners when according to fresh FrameMetrics
    the scroll position hasn't been changed, but only viewport's height has
    (this is the case of open VKB).
    
    Here we rely on hacks in APZC notifying UI code about actual composition bounds
    and on some logic in the UI notifying embedhelper about the state of VKB.
