### PR TITLE
Remove correct symlink before trying to create it again.

### DIFF
--- a/link_to_system.sh
+++ b/link_to_system.sh
@@ -52,7 +52,7 @@ jscomps/RtspProtocolHandler.js
 
 for str in $FILES_LIST; do
     fname="${str##*/}"
-    rm -f $TARGET_DIR/$fname;
+    rm -f $TARGET_DIR/components/$fname;
     ln -s $(pwd)/$str $TARGET_DIR/components/$fname;
 done
 


### PR DESCRIPTION
The link_to_system.sh script tried to remove a non existing symlink
before trying to recreate it. As a result the script output was polluted
with ln warnings telling the user link target already exists.