### PR TITLE
[embedlite-components] Tweak UA override for youtube.com. Fixes JB#31713

### DIFF
--- a/jscomps/UserAgentOverrideHelper.js
+++ b/jscomps/UserAgentOverrideHelper.js
@@ -98,11 +98,7 @@ var UserAgent = {
         }
         if (!ua.contains("Android")) {
           // Nexus 7 Android chrome has best capabilities
-          if (ua.contains("Mobile")) {
-            return ua.replace("Linux", "Android 4.4.2").replace("Unix", "Android 4.4.2").replace("Mobile", "").replace("Maemo", "");
-          } else {
-            return ua.replace("Linux", "Android 4.4.2").replace("Unix", "Android 4.4.2");
-          }
+          return ua.replace("Linux", "Android 4.4.2").replace("Unix", "Android 4.4.2");
         }
       } else if (this.NOKIA_HERE_DOMAIN.test(aUri.host)) {
         // Send the phone UA to here


### PR DESCRIPTION
It seems youtube has changed it user agent recognition logic again which
results in sailfish-browser receiving content which relies on external
android youtube app for actual video playback. This basically breaks
youtube playback on sailfish.

The fix seems to be rather simple. Don't drop Maemo and Mobile keywords
from the UA. When youtube servers get UA with Android, Maemo and Mobile
keywords they again give us version of the page with HTML5 video
element.