### PR TITLE
[embedlite-components] CSSPoint x and y values are floats not integers.

### DIFF
--- a/touchhelper/EmbedTouchListener.cpp
+++ b/touchhelper/EmbedTouchListener.cpp
@@ -68,12 +68,12 @@ void EmbedTouchListener::HandleSingleTap(const CSSPoint& aPoint, int32_t, const 
 
 void EmbedTouchListener::HandleLongTap(const CSSPoint& aPoint, int32_t, const mozilla::layers::ScrollableLayerGuid&, uint64_t)
 {
-    LOGT("pt[%i,%i]", aPoint.x, aPoint.y);
+    LOGT("pt[%f,%f]", aPoint.x, aPoint.y);
 }
 
 void EmbedTouchListener::HandleLongTapUp(const CSSPoint& aPoint, int32_t, const mozilla::layers::ScrollableLayerGuid&)
 {
-    LOGT("pt[%i,%i]", aPoint.x, aPoint.y);
+    LOGT("pt[%f,%f]", aPoint.x, aPoint.y);
 }
 
 void EmbedTouchListener::SendAsyncScrollDOMEvent(bool aIsRoot,
@@ -120,7 +120,7 @@ void EmbedTouchListener::RequestContentRepaint(const mozilla::layers::FrameMetri
 
 void EmbedTouchListener::HandleDoubleTap(const CSSPoint& aPoint, int32_t, const mozilla::layers::ScrollableLayerGuid&)
 {
-    LOGT("pt[%i,%i]", aPoint.x, aPoint.y);
+    LOGT("pt[%f,%f]", aPoint.x, aPoint.y);
     // We haven't received a metrics update yet; don't do anything.
     if (!mGotViewPortUpdate) {
         return;


### PR DESCRIPTION
Fix logging so point coordinates are reported correctly.