### PR TITLE
[embedlite-components] Fix warning about condition not having mathematical meaning.

### DIFF
--- a/touchhelper/EmbedTouchListener.cpp
+++ b/touchhelper/EmbedTouchListener.cpp
@@ -260,7 +260,7 @@ EmbedTouchListener::ZoomToElement(nsIDOMElement* aElement, int aClickY, bool aCa
             zoomed = true;
         }
     }
-    else if (elementAspectRatio < viewportAspectRatio < 1) {
+    else if (elementAspectRatio < viewportAspectRatio && viewportAspectRatio < 1) {
         if ((clrect.height < mCssCompositedRect.height && aCanZoomIn) ||
             (clrect.height > mCssCompositedRect.height && aCanZoomOut) ) {
             mService->ZoomToRect(mTopWinid, clrect.x, clrect.y, clrect.width, clrect.height);


### PR DESCRIPTION
Spotted when compiling the code with gcc 4.8.3:
 warning: comparisons like ‘X<=Y<=Z’ do not have their mathematical meaning