### PR TITLE
[embedlite-components] Fix compilation against system nspr.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -57,7 +57,11 @@ AS_IF([test "x$with_system_nspr" = "xyes"],
 if test "$OBJ_PATH" != ""; then
 SDK_DIR=$OBJ_PATH/dist
 IDL_DIR=$OBJ_PATH/dist/idl
-ENGINE_CFLAGS="-I$OBJ_PATH/dist/include -I$OBJ_PATH/dist/include/nspr -I$OBJ_PATH/dist/include/mozilla -I$OBJ_PATH/dist/include/dom -I/usr/include/nspr4"
+ENGINE_CFLAGS="-I$OBJ_PATH/dist/include -I$OBJ_PATH/dist/include/mozilla -I$OBJ_PATH/dist/include/dom"
+AS_IF([test "x$with_system_nspr" = "xyes"],
+  [ENGINE_CFLAGS="${ENGINE_CFLAGS} `pkg-config --cflags-only-I nspr`"],
+  [ENGINE_CFLAGS="${ENGINE_CFLAGS} -I$OBJ_PATH/dist/include/nspr"]
+)
 ENGINE_LIBS="-L$OBJ_PATH/dist/sdk/lib -lxpcomglue_s -lxul"
 else
 PKG_CHECK_MODULES(ENGINE, libxul $NSPR,


### PR DESCRIPTION
Don't hardcode the system nspr path to /usr/include/nspr4. Instead use
pkg-config to determine correct path. Do it only in case we're building
the code against system nspr. In case we use bundled gecko version
system include paths should not be passed to the compiler.