### PR TITLE
Initialize nsLoginManager only after profile is accessible

### DIFF
--- a/jscomps/EmbedLiteGlobalHelper.js
+++ b/jscomps/EmbedLiteGlobalHelper.js
@@ -58,16 +58,20 @@ EmbedLiteGlobalHelper.prototype = {
         dump("EmbedLiteGlobalHelper app-startup\n");
         Services.obs.addObserver(this, "invalidformsubmit", false);
         Services.obs.addObserver(this, "xpcom-shutdown", false);
-        // Init LoginManager, not important for gecko > 32
+        Services.obs.addObserver(this, "profile-after-change", false);
+        break;
+      }
+      case "invalidformsubmit": {
+        dump("EmbedLiteGlobalHelper invalidformsubmit\n");
+        break;
+      }
+      case "profile-after-change": {
+        // Init LoginManager
         try {
           Cc["@mozilla.org/login-manager;1"].getService(Ci.nsILoginManager);
         } catch (e) {
           dump("E login manager\n");
         }
-        break;
-      }
-      case "invalidformsubmit": {
-        dump("EmbedLiteGlobalHelper invalidformsubmit\n");
         break;
       }
       case "xpcom-shutdown": {


### PR DESCRIPTION
At least since Gecko38 nsLoginManager tries to initialize storage is a
part of its initialization procedure. But the storage can't be
initialized until the user profile is available for a component.
It's a wrong assumption that the profile is available upon the
"app-startup" notification. In fact the availability of the profile
is announced with the "profile-after-change" notification.