### PR TITLE
[embedlite-components] Add support for site specific UA override. Contributes to JB#34904

### DIFF
--- a/jscomps/EmbedLiteJSComponents.manifest
+++ b/jscomps/EmbedLiteJSComponents.manifest
@@ -64,6 +64,7 @@ category app-startup EmbedLiteErrorPageHandler service,@mozilla.org/embedlite-er
 # UserAgentOverrideHelper.js
 component {69d68654-b5a0-11e2-bb91-2b8ad5eb98ac} UserAgentOverrideHelper.js
 contract @mozilla.org/embedlite-uahelper-component;1 {69d68654-b5a0-11e2-bb91-2b8ad5eb98ac}
+contract @mozilla.org/dom/site-specific-user-agent;1 {69d68654-b5a0-11e2-bb91-2b8ad5eb98ac}
 category app-startup UserAgentOverrideHelper service,@mozilla.org/embedlite-uahelper-component;1
 
 # XPIDialogService.js


### PR DESCRIPTION
This makes possible to use general.useragent.override.\* overrides
with simple replace syntax given that complex override is not applied.

Instantiation of the UserAgent is deferred a bit so that we do not
end up initializing UserAgentOverrides before general.useragent.override
is applied. As UserAgent was initialized on that application startup,
the simple hash separated user agent fixing did not work. This happened
because nsIHttpProtocolHandler was not yet aware of the override.
Thus, causing UserAgentOverrides to fail to replace ua.
